### PR TITLE
Allow singleplayer, increase default max players from 2 to 16

### DIFF
--- a/mp/src/game/server/hl2mp/hl2mp_gameinterface.cpp
+++ b/mp/src/game/server/hl2mp/hl2mp_gameinterface.cpp
@@ -18,8 +18,14 @@
 
 void CServerGameClients::GetPlayerLimits( int& minplayers, int& maxplayers, int &defaultMaxPlayers ) const
 {
+#ifndef HL2SB
 	minplayers = defaultMaxPlayers = 2; 
 	maxplayers = 16;
+#else
+	minplayers = 1; 
+	maxplayers = MAX_PLAYERS;
+	defaultMaxPlayers = 16;
+#endif
 }
 
 // -------------------------------------------------------------------------------------------- //


### PR DESCRIPTION
Copy of https://github.com/Planimeter/hl2sb-src/pull/19 since it applies to SDK2013 too. This time, I know it works since I have tried it a long time ago.