### PR TITLE
Fix Lua-Side VGUI GameUI panel

### DIFF
--- a/mp/src/game/client/hl2/vgui_rootpanel_hl2.cpp
+++ b/mp/src/game/client/hl2/vgui_rootpanel_hl2.cpp
@@ -25,7 +25,10 @@ C_ScriptedBaseGameUIPanel *g_pScriptedBaseGameUIPanel = NULL;
 //-----------------------------------------------------------------------------
 void VGUI_CreateGameUIRootPanel( void )
 {
-	g_pScriptedBaseGameUIPanel = new C_ScriptedBaseGameUIPanel( enginevgui->GetPanel( PANEL_GAMEUIDLL ) );
+	// @ThePixelMoon: https://github.com/ThePixelMoon/OpenMod/commit/a19a0ba86d634402690f334b9666e18b1aa23c2b
+	//				  Weird, this fix was the only thing to make this whole thing work. Maybe i was the only one
+	//				  to experience that bug? Dunno.
+	g_pScriptedBaseGameUIPanel = new C_ScriptedBaseGameUIPanel( enginevgui->GetPanel( PANEL_ROOT ) );
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Well, back in my OpenMod days... :nerd_face:

In all seriousness, i'm sure this is a SDK2013-specific bug. I don't really know if anyone else have experienced it, but I did. The VGUI panels in Lua weren't just opening before this.